### PR TITLE
Update authenticate_pam.cc

### DIFF
--- a/authenticate_pam.cc
+++ b/authenticate_pam.cc
@@ -25,7 +25,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <v8.h>
 #include <unistd.h>
 #include <uv.h>
-#include <string>
+#include <string.h>
 #include <stdlib.h>
 
 #include <security/pam_appl.h>


### PR DESCRIPTION
fixed the #include <string> line.  changed to #include <string.h> because it causes compilation to fail.
