### PR TITLE
fixing issue on compiling by npm/qyp due to updated libuv API

### DIFF
--- a/authenticate_pam.cc
+++ b/authenticate_pam.cc
@@ -95,7 +95,7 @@ void doing_auth_thread(uv_work_t* req) {
 	return;
 }
 
-void after_doing_auth(uv_work_t* req) {
+void after_doing_auth(uv_work_t* req, int status) {
 	HandleScope scope;
 
 	auth_context* m = static_cast<auth_context*>(req->data);


### PR DESCRIPTION
API of libuv has changed obviously, now providing second mandatory argument on callback invoked after doing a queued work. This extension can't be compiled under current stable release of node/npm without.
