### PR TITLE
fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,7 @@
 {
   "name": "authenticate-pam",
   "version": "v0.2.2",
-  "scripts": {
-    "preinstall": "node-gyp configure && node-gyp build",
-    "preuninstall": "rm -rf build/*"
-  },
+  "gypfile": true,
   "main": "build/Release/authenticate_pam.node",
   "description": "Asynchronous PAM authentication for Node.JS",
   "homepage": "https://github.com/RushPL/node-authenticate-pam",


### PR DESCRIPTION
@Rush, This fixes a few errors including one I keep getting:

```
node -e "require('nan')"' returned exit status 1. while trying to load binding.gyp
```
