### PR TITLE
replacing deprecated Nan:MakeCallback with Nan::AsyncResource

### DIFF
--- a/authenticate_pam.cc
+++ b/authenticate_pam.cc
@@ -104,7 +104,8 @@ void after_doing_auth(uv_work_t* req, int status) {
 		args[0] = Nan::New<String>(m->errorString.c_str()).ToLocalChecked();
 	}
 
-  Nan::MakeCallback(Nan::GetCurrentContext()->Global(), Nan::New(m->callback), 1, args);
+	Nan::AsyncResource *asyncResource = new Nan::AsyncResource("callback");
+	asyncResource->runInAsyncScope(Nan::GetCurrentContext()->Global(), Nan::New(m->callback), 1, args);
 
 	m->callback.Reset();
 


### PR DESCRIPTION
The replacement is safe and it is strongly advised according the new https://github.com/nodejs/nan APIs

https://github.com/nodejs/nan/blob/master/doc/node_misc.md#api_nan_asyncresource

@WeiAnAN was definitely right in making this crucial modification